### PR TITLE
Add hostname and vendor discovery

### DIFF
--- a/codex_run_tests.sh
+++ b/codex_run_tests.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+pytest -q

--- a/src/discover_hosts.py
+++ b/src/discover_hosts.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from typing import List, Dict
+import re
+import requests
+
+from . import network_utils
+
+OUI_FILE = Path(__file__).with_name("oui.txt")
+
+
+def _lookup_vendor(mac: str) -> str | None:
+    if not mac:
+        return None
+    prefix = re.sub(r"[^0-9A-Fa-f]", "", mac)[:6].upper()
+    if OUI_FILE.exists():
+        try:
+            for line in OUI_FILE.read_text().splitlines():
+                if line[:6].upper() == prefix:
+                    parts = line.split(None, 1)
+                    if len(parts) == 2:
+                        return parts[1].strip()
+        except Exception:
+            pass
+    try:
+        resp = requests.get(f"https://api.macvendors.com/{mac}", timeout=5)
+        if resp.status_code == 200:
+            text = resp.text.strip()
+            if text:
+                return text
+    except Exception:
+        pass
+    return None
+
+
+def discover_hosts(network: str) -> List[Dict[str, str]]:
+    hosts = network_utils._run_nmap_scan(network)
+    for host in hosts:
+        mac = host.get("mac")
+        if mac and not host.get("vendor"):
+            vendor = _lookup_vendor(mac)
+            if vendor:
+                host["vendor"] = vendor
+        if "hostname" not in host:
+            host["hostname"] = ""
+    return hosts

--- a/src/network_utils.py
+++ b/src/network_utils.py
@@ -1,0 +1,85 @@
+import subprocess
+import re
+from typing import List, Dict
+
+
+def _parse_nmap_output(output: str) -> List[Dict[str, str]]:
+    hosts = []
+    current = None
+    for line in output.splitlines():
+        line = line.strip()
+        if line.startswith("Nmap scan report for"):
+            match = re.match(r"Nmap scan report for (?:(?P<hostname>[^\s]+) )?\((?P<ip>[^)]+)\)", line)
+            if match:
+                current = {
+                    "ip": match.group("ip"),
+                }
+                hostname = match.group("hostname")
+                if hostname and hostname != match.group("ip"):
+                    current["hostname"] = hostname
+                hosts.append(current)
+            else:
+                parts = line.split()
+                ip = parts[-1]
+                current = {"ip": ip}
+                if len(parts) >= 5:
+                    current["hostname"] = parts[4]
+                hosts.append(current)
+        elif line.startswith("MAC Address:") and current is not None:
+            parts = line.split("MAC Address:", 1)[1].strip().split(" ")
+            if parts:
+                current["mac"] = parts[0]
+                if len(parts) > 1:
+                    current["vendor"] = " ".join(parts[1:]).strip()
+    return hosts
+
+
+def _nbtscan(ips: List[str]) -> Dict[str, str]:
+    if not ips:
+        return {}
+    try:
+        result = subprocess.run(["nbtscan", "-f"] + ips, capture_output=True, text=True, check=False)
+        mapping = {}
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if not line or line.startswith("doing"):
+                continue
+            parts = re.split(r"\s+", line)
+            if len(parts) >= 2:
+                mapping[parts[0]] = parts[1]
+        return mapping
+    except FileNotFoundError:
+        return {}
+
+
+def _avahi_resolve(ips: List[str]) -> Dict[str, str]:
+    mapping = {}
+    for ip in ips:
+        try:
+            result = subprocess.run(["avahi-resolve", "-a", ip], capture_output=True, text=True, check=False)
+            for line in result.stdout.splitlines():
+                line = line.strip()
+                parts = line.split()
+                if len(parts) >= 2:
+                    mapping[ip] = parts[1]
+        except FileNotFoundError:
+            break
+    return mapping
+
+
+def _run_nmap_scan(network: str) -> List[Dict[str, str]]:
+    try:
+        result = subprocess.run(["nmap", "-sn", network], capture_output=True, text=True, check=False)
+        hosts = _parse_nmap_output(result.stdout)
+    except FileNotFoundError:
+        hosts = []
+    ips = [h["ip"] for h in hosts]
+    nbts = _nbtscan(ips)
+    avahi = _avahi_resolve(ips)
+    for host in hosts:
+        ip = host["ip"]
+        if ip in nbts:
+            host["hostname"] = nbts[ip]
+        elif ip in avahi and not host.get("hostname"):
+            host["hostname"] = avahi[ip]
+    return hosts

--- a/tests/test_discover_hosts.py
+++ b/tests/test_discover_hosts.py
@@ -1,0 +1,32 @@
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from src import discover_hosts
+
+
+def test_discover_hosts_includes_hostname_and_vendor(monkeypatch):
+    sample_hosts = [{
+        "ip": "192.168.0.2",
+        "mac": "AA:BB:CC:DD:EE:FF",
+        "hostname": "test-host"
+    }]
+
+    monkeypatch.setattr(discover_hosts.network_utils, "_run_nmap_scan", lambda net: sample_hosts)
+
+    class DummyResp:
+        status_code = 200
+        text = "DummyVendor"
+
+    monkeypatch.setattr(discover_hosts.requests, "get", lambda url, timeout=5: DummyResp())
+    monkeypatch.setattr(discover_hosts, "OUI_FILE", pathlib.Path("/nonexistent/oui.txt"))
+
+    result = discover_hosts.discover_hosts("192.168.0.0/24")
+    assert result == [{
+        "ip": "192.168.0.2",
+        "mac": "AA:BB:CC:DD:EE:FF",
+        "hostname": "test-host",
+        "vendor": "DummyVendor",
+    }]


### PR DESCRIPTION
## Summary
- add network utilities that combine `nmap`, `nbtscan` and `avahi-resolve` to determine hostnames
- enrich host discovery by looking up vendor names and falling back to `api.macvendors.com`
- extend tests to ensure hostnames and vendor names are present

## Testing
- `bash codex_run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a8843713f08323907790169c4c4d98